### PR TITLE
Overwrite delete method. Ignore modify time since that does not work on ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ your `INSTALLED_APPS`:
         'collectfast',
     )
 
+Settings
+--------
+
+The original Django `collectstatic` command will not copy the file if the target 
+file modification time is later than the source file. This happens all the time when
+we are using s3. And if you think about cases of rolling back source code, this
+logic does not make any sense. Here we ignore the modification time completely but
+provide you a flag. If you really want it, you can set the following flag to true in
+your `settings.py` file:
+
+    COLLECTSTATIC_KEEP_NEWER = True
+
 Usage
 -----
 

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -6,6 +6,7 @@ from optparse import make_option
 import datetime
 
 from django.contrib.staticfiles.management.commands import collectstatic
+from django.conf import settings
 from django.core.cache import cache
 from django.core.files.storage import FileSystemStorage
 from django.core.management.base import CommandError
@@ -93,6 +94,14 @@ class Command(collectstatic.Command):
 
         return super(Command, self).copy_file(path, prefixed_path,
                                               source_storage)
+
+    def delete_file(self, path, prefixed_path, source_storage):
+        if getattr(settings, "COLLECTSTATIC_KEEP_NEWER", False):
+            return super(Command, self).delete_file(path, prefixed_path, source_storage)
+
+        self.log("Ignore modify time and deleting '%s'" % path)
+        self.storage.delete(prefixed_path)
+        return True
 
     def handle_noargs(self, **options):
         self.set_options(**options)


### PR DESCRIPTION
...s3 and in case of rollback. Provide flag. Updated README.

I like the idea of collectfast. I feel using checksum means modify time should not be considered at all. Especially s3 had gave me so many problems around time tags.

Thanks.

--Gordon
