### PR TITLE
Normalize path names so that storage location is respected.

### DIFF
--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -93,8 +93,8 @@ class Command(collectstatic.Command):
             # Invalidate cached versions of lookup if copy is done
             self.destroy_lookup(normalized_path)
 
-        return super(Command, self).copy_file(path, prefixed_path,
-                                              source_storage)
+        return super(Command, self).copy_file(
+            path, prefixed_path, source_storage)
 
     def delete_file(self, path, prefixed_path, source_storage):
         """Override delete_file to skip modified time and exists lookups"""


### PR DESCRIPTION
Fix #20 

I found #23 to be a cleaner solution than #21. Just modified it to use `normalized_path` for the `destroy_lookup` call as well. I'll need to test this as well. If someone can confirm that it's working that would be great.
