### PR TITLE
Added COLLECTFAST_CACHE setting so backend cache can be configured by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ INSTALLED_APPS = (
 )
 ```
 
+Optionally, you can set `COLLECTFAST_CACHE` in your Django settings.py file to specify a specific cache backend for collectfast to use.  By default it is set to the `default` cache.
+
 Usage
 -----
 

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -9,12 +9,14 @@ import hashlib
 from optparse import make_option
 import datetime
 
+from django.conf import settings
 from django.contrib.staticfiles.management.commands import collectstatic
-from django.core.cache import cache
+from django.core.cache import get_cache
 from django.core.files.storage import FileSystemStorage
 from django.core.management.base import CommandError
 from django.utils.encoding import smart_str
 
+cache = get_cache(getattr(settings, "COLLECTFAST_CACHE", "default"))
 
 class Command(collectstatic.Command):
     option_list = collectstatic.Command.option_list + (


### PR DESCRIPTION
This PR should close issue #14.

Users can optionally set the `COLLECTFAST_CACHE` setting to the name of an alternate Django cache backend.  If the setting is not present, it will use `default` -- which is the current behavior.
