### PR TITLE
Make normalized_path use prefixed_path

### DIFF
--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -82,7 +82,7 @@ class Command(collectstatic.Command):
         if not self.ignore_etag and not self.dry_run:
             try:
                 storage_lookup = self.get_lookup(normalized_path)
-                local_file = source_storage.open(prefixed_path)
+                local_file = source_storage.open(path)
 
                 # Create md5 checksum from local file
                 file_contents = local_file.read()


### PR DESCRIPTION
Currently collectfast ignores the prefix on source storages when looking up etags.
So if you have in settings something like:

```
STATICFILES_DIRS = [
    os.path.join(PACKAGE_ROOT, "static"),
    ('ng', os.path.join(PACKAGE_ROOT, "angular/app")),
]
```

etag lookups on all static files within angular/app fail and the files are re-copied to `STATIC_ROOT/ng/` every time.

In this case when copying `PACKAGE_ROOT/angular/app/index.html`, `path="index.html"` and `prefixed_path="ng/index.html"`
(source_storage is a FileSystemStorage object with prefix='ng')
