### PR TITLE
Fix Windows paths.

### DIFF
--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -107,7 +107,7 @@ class Command(collectstatic.Command):
 
         """
         if self.collectfast_enabled and not self.dry_run:
-            normalized_path = self.storage._normalize_name(prefixed_path)
+            normalized_path = self.storage._normalize_name(prefixed_path).replace('\\', '/')
             try:
                 storage_lookup = self.get_lookup(normalized_path)
                 local_etag = self.get_file_hash(source_storage, path)


### PR DESCRIPTION
Replace double backslash - a product of Windows paths - with normalized
forward slash.