### PR TITLE
Add boto3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ env:
   matrix:
     - TOXENV=py27-django18
     - TOXENV=py27-django19
+    - TOXENV=py27-django110
     - TOXENV=py33-django18
     - TOXENV=py34-django18
     - TOXENV=py34-django19
     - TOXENV=py35-django18
     - TOXENV=py35-django19
+    - TOXENV=py35-django110
     - TOXENV=flake8
 # work-around for Python 3.5
 addons:

--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,13 @@ Contribution
 ------------
 
 Please feel free to contribute by using issues and pull requests.
-Discussion is open and welcome. Testing is currently being implemented
-and will be mandatory for new features once merged.
+Discussion is open and welcome.
+
+**Testing**
+
+To run tests, setup a virtualenv and install tox with ``pip install tox`` then
+run ``tox`` in the project directory. To only run tests for a certain environment
+run e.g. ``tox -e py35-django110``.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Collectfast – A Faster Collectstatic
 ====================================
 
-|Downloads| |Build Status| |Windows Build Status| |Coverage Status| |Join the chat at
+|Build Status| |Windows Build Status| |Coverage Status| |Join the chat at
 https://gitter.im/antonagestam/collectfast|
 
 The fast ``collectstatic`` for Django projects with S3 as storage
@@ -125,8 +125,6 @@ Original idea taken from `this
 snippet. <http://djangosnippets.org/snippets/2889/>`__
 
 
-.. |Downloads| image:: https://img.shields.io/pypi/dm/collectfast.svg
-   :target: https://pypi.python.org/pypi/Collectfast
 .. |Build Status| image:: https://api.travis-ci.org/antonagestam/collectfast.svg?branch=master
    :target: https://travis-ci.org/antonagestam/collectfast
 .. |Windows Build Status| image:: https://ci.appveyor.com/api/projects/status/github/antonagestam/collectfast?branch=master&svg=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ environment:
 
     # Python 2.7.10 is the latest version and is not pre-installed.
 
-    - PYTHON: "C:\\Python27.10"
-      PYTHON_VERSION: "2.7.10"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Python27.10"
+    #   PYTHON_VERSION: "2.7.10"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27.10-x64"
       PYTHON_VERSION: "2.7.10"
@@ -21,9 +21,9 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Python34"
+    #   PYTHON_VERSION: "3.4.x" # currently 3.4.3
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
@@ -31,9 +31,9 @@ environment:
 
     # Python versions not pre-installed
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Python35"
+    #   PYTHON_VERSION: "3.5.0"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.0"

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -26,7 +26,7 @@ debug = getattr(
 class Command(collectstatic.Command):
 
     etags = None
-    cache_key_prefix = 'collectfast3_asset_'
+    cache_key_prefix = 'collectfast03_asset_'
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -25,8 +25,8 @@ debug = getattr(
 
 class Command(collectstatic.Command):
 
-    lookups = None
-    cache_key_prefix = 'collectfast_asset_'
+    etags = None
+    cache_key_prefix = 'collectfast3_asset_'
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -39,9 +39,7 @@ class Command(collectstatic.Command):
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)
-
         self.storage.preload_metadata = True
-
         if getattr(settings, 'AWS_PRELOAD_METADATA', False) is not True:
             self._pre_setup_log(
                 "----> WARNING!\nCollectfast does not work properly without "
@@ -53,7 +51,8 @@ class Command(collectstatic.Command):
         if self.ignore_etag:
             self.collectfast_enabled = False
         else:
-            self.collectfast_enabled = getattr(settings, "COLLECTFAST_ENABLED", True)
+            self.collectfast_enabled = getattr(
+                settings, "COLLECTFAST_ENABLED", True)
         super(Command, self).set_options(**options)
 
     def _pre_setup_log(self, message):
@@ -76,30 +75,39 @@ class Command(collectstatic.Command):
             path_hash = hashlib.md5(path.encode('utf-8')).hexdigest()
         return self.cache_key_prefix + path_hash
 
-    def get_storage_lookup(self, path):
-        return self.storage.bucket.lookup(path)
+    def get_boto3_etag(self, path):
+        try:
+            return self.storage.bucket.Object(path).e_tag
+        except:
+            return None
 
-    def get_lookup(self, path):
-        """Get lookup from local dict, cache or S3 — in that order"""
+    def get_remote_etag(self, path):
+        try:
+            return self.storage.bucket.get_key(path).etag
+        except AttributeError:
+            return self.get_boto3_etag(path)
 
-        if self.lookups is None:
-            self.lookups = {}
+    def get_etag(self, path):
+        """Get etag from local dict, cache or S3 — in that order"""
 
-        if path not in self.lookups:
+        if self.etags is None:
+            self.etags = {}
+
+        if path not in self.etags:
             cache_key = self.get_cache_key(path)
             cached = cache.get(cache_key, False)
 
             if cached is False:
-                self.lookups[path] = self.get_storage_lookup(path)
-                cache.set(cache_key, self.lookups[path])
+                self.etags[path] = self.get_remote_etag(path)
+                cache.set(cache_key, self.etags[path])
             else:
-                self.lookups[path] = cached
+                self.etags[path] = cached
 
-        return self.lookups[path]
+        return self.etags[path]
 
-    def destroy_lookup(self, path):
-        if self.lookups is not None and path in self.lookups:
-            del self.lookups[path]
+    def destroy_etag(self, path):
+        if self.etags is not None and path in self.etags:
+            del self.etags[path]
         cache.delete(self.get_cache_key(path))
 
     def get_file_hash(self, storage, path):
@@ -114,14 +122,14 @@ class Command(collectstatic.Command):
 
         """
         if self.collectfast_enabled and not self.dry_run:
-            normalized_path = self.storage._normalize_name(prefixed_path).replace('\\', '/')
+            normalized_path = self.storage._normalize_name(
+                prefixed_path).replace('\\', '/')
             try:
-                storage_lookup = self.get_lookup(normalized_path)
+                storage_etag = self.get_etag(normalized_path)
                 local_etag = self.get_file_hash(source_storage, path)
 
                 # Compare hashes and skip copying if matching
-                if (hasattr(storage_lookup, 'etag') and
-                        storage_lookup.etag == local_etag):
+                if storage_etag == local_etag:
                     self.log(
                         "Skipping '%s' based on matching file hashes" % path,
                         level=2)
@@ -138,7 +146,7 @@ class Command(collectstatic.Command):
                     "default collectstatic." % e.message))
 
             # Invalidate cached versions of lookup if copy is done
-            self.destroy_lookup(normalized_path)
+            self.destroy_etag(normalized_path)
 
         return super(Command, self).copy_file(
             path, prefixed_path, source_storage)
@@ -196,7 +204,8 @@ Type 'yes' to continue, or 'no' to cancel: """ % (
                         "%(destination)s%(unmodified)s%(post_processed)s.\n")
             summary = template % {
                 'modified_count': modified_count,
-                'identifier': 'static file' + (modified_count != 1 and 's' or ''),
+                'identifier': 'static file' + (
+                    modified_count != 1 and 's' or ''),
                 'action': self.symlink and 'symlinked' or 'copied',
                 'destination': (destination_path and " to '%s'"
                                 % destination_path or ''),

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -57,7 +57,7 @@ class TestCommand(CollectfastTestCase):
         mocked_lookup.return_value = 'a fresh lookup'
         mocked_cache.return_value = cached_value
         command = self.get_command()
-        ret_val = command.get_lookup(path)
+        ret_val = command.get_etag(path)
         return ret_val, mocked_lookup, mocked_cache
 
     def get_fresh_lookup(self, path):
@@ -89,11 +89,11 @@ class TestCommand(CollectfastTestCase):
         c = self.get_command()
         path = '/another/unique/path'
         cache_key = c.get_cache_key(path)
-        c.get_lookup(path)
+        c.get_etag(path)
         self.assertEqual(cache.get(cache_key), mocked_lookup.return_value)
         self.assertEqual(c.lookups[path], mocked_lookup.return_value)
 
-        c.destroy_lookup(path)
+        c.destroy_etag(path)
         self.assertEqual(cache.get(cache_key, 'empty'), 'empty')
         self.assertNotIn(path, c.lookups)
 

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -52,7 +52,7 @@ class TestCommand(CollectfastTestCase):
 
     @patch("collectfast.management.commands.collectstatic.cache.get")
     @patch("collectfast.management.commands.collectstatic.Command"
-           ".get_storage_lookup")
+           ".get_remote_etag")
     def mock_get_lookup(self, path, cached_value, mocked_lookup, mocked_cache):
         mocked_lookup.return_value = 'a fresh lookup'
         mocked_cache.return_value = cached_value
@@ -83,7 +83,7 @@ class TestCommand(CollectfastTestCase):
         self.assertEqual(ret_val, 'a cached lookup')
 
     @patch("collectfast.management.commands.collectstatic.Command"
-           ".get_storage_lookup")
+           ".get_remote_etag")
     def test_destroy_lookup(self, mocked_lookup):
         mocked_lookup.return_value = 'a fake lookup'
         c = self.get_command()
@@ -91,11 +91,11 @@ class TestCommand(CollectfastTestCase):
         cache_key = c.get_cache_key(path)
         c.get_etag(path)
         self.assertEqual(cache.get(cache_key), mocked_lookup.return_value)
-        self.assertEqual(c.lookups[path], mocked_lookup.return_value)
+        self.assertEqual(c.etags[path], mocked_lookup.return_value)
 
         c.destroy_etag(path)
         self.assertEqual(cache.get(cache_key, 'empty'), 'empty')
-        self.assertNotIn(path, c.lookups)
+        self.assertNotIn(path, c.etags)
 
     def test_make_sure_it_has_ignore_etag(self):
         command = self.get_command()
@@ -123,7 +123,7 @@ class TestGetFileHash(CollectfastTestCase):
 class TestCopyFile(CollectfastTestCase):
     @patch("collectfast.management.commands.collectstatic.collectstatic.Command"
            ".copy_file")
-    @patch("collectfast.management.commands.collectstatic.Command.get_lookup")
+    @patch("collectfast.management.commands.collectstatic.Command.get_etag")
     def call_copy_file(self, mocked_lookup, mocked_copy_file_super, **kwargs):
         options = {
             "interactive": False,
@@ -138,9 +138,7 @@ class TestCopyFile(CollectfastTestCase):
         path = options.pop('path', '/a/sweet/path')
 
         if 'lookup_hash' in options:
-            class FakeLookup:
-                etag = options.pop('lookup_hash')
-            mocked_lookup.return_value = FakeLookup()
+            mocked_lookup.return_value = options.pop('lookup_hash')
 
         c = self.get_command()
         c.storage = options.pop('storage', BotolikeStorage())
@@ -165,7 +163,7 @@ class TestCopyFile(CollectfastTestCase):
     @patch("collectfast.management.commands.collectstatic.Command"
            ".get_file_hash")
     @patch("collectfast.management.commands.collectstatic.Command"
-           ".destroy_lookup")
+           ".destroy_etag")
     def test_calls_super(self, mock_destroy_lookup, mock_get_file_hash):
         """`copy_file` properly calls super method"""
         path = '/a/sweet/path'

--- a/runtests.py
+++ b/runtests.py
@@ -54,6 +54,7 @@ def main():
             "django.contrib.auth",
             "django.contrib.contenttypes",
             app_name,
+            "django.contrib.staticfiles",
         ),
         "STATIC_URL": "/staticfiles/",
         "STATIC_ROOT": "./",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 setup(
     name='Collectfast',
     description='Collectstatic on Steroids',
-    version='0.2.3',
+    version='0.3.0',
     long_description=open('README.rst').read(),
     author='Anton Agestam',
     author_email='msn@antonagestam.se',
@@ -14,7 +14,7 @@ setup(
     url='https://github.com/antonagestam/collectfast/',
     license='Creative Commons Attribution-ShareAlike 3.0 Unported License',
     include_package_data=True,
-    install_requires=['Django>=1.4', 'python-dateutil>=2.1', 'pytz>=2014.2', ],
+    install_requires=['Django>=1.8', 'python-dateutil>=2.1', 'pytz>=2014.2', ],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py{27,33,34,35}-django{18,19}
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     mock==1.3.0
     coveralls
 commands =


### PR DESCRIPTION
- Adds support for boto3
- Only stores the file etag in cache instead of the entire lookup
- Updates tests and documentation

fixes #77 