### PR TITLE
Use public APIs and update supported versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .coverage
 .DS_Store
 .coveragerc.swp
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: python
+python:
+  - 2.7
+  - pypy
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy3
 install:
   - pip install tox
 script: tox
@@ -19,6 +27,9 @@ env:
     - TOXENV=pypy-django18
     - TOXENV=pypy-django110
     - TOXENV=pypy-django111
+    - TOXENV=pypy3-django18
+    - TOXENV=pypy3-django110
+    - TOXENV=pypy3-django111
     - TOXENV=flake8
 # work-around for Python 3.5
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ sudo: false
 env:
   matrix:
     - TOXENV=py27-django18
-    - TOXENV=py27-django19
     - TOXENV=py27-django110
+    - TOXENV=py27-django111
     - TOXENV=py33-django18
     - TOXENV=py34-django18
-    - TOXENV=py34-django19
+    - TOXENV=py34-django110
+    - TOXENV=py34-django111
     - TOXENV=py35-django18
-    - TOXENV=py35-django19
     - TOXENV=py35-django110
+    - TOXENV=py35-django111
+    - TOXENV=py36-django111
     - TOXENV=flake8
 # work-around for Python 3.5
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: python
 python:
-  - 2.7
-  - pypy
-  - 3.3
-  - 3.4
-  - 3.5
   - 3.6
-  - pypy3
 install:
   - pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - TOXENV=py35-django110
     - TOXENV=py35-django111
     - TOXENV=py36-django111
+    - TOXENV=pypy-django18
+    - TOXENV=pypy-django110
+    - TOXENV=pypy-django111
     - TOXENV=flake8
 # work-around for Python 3.5
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ env:
     - TOXENV=pypy-django18
     - TOXENV=pypy-django110
     - TOXENV=pypy-django111
-    - TOXENV=pypy3-django18
-    - TOXENV=pypy3-django110
-    - TOXENV=pypy3-django111
     - TOXENV=flake8
 # work-around for Python 3.5
 addons:

--- a/collectfast/etag.py
+++ b/collectfast/etag.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 
 from django.core.cache import caches
+from storages.utils import safe_join
 
 from collectfast import settings
 
@@ -35,8 +36,8 @@ def get_remote_etag(storage, prefixed_path):
     """
     Get etag of path from S3 using boto or boto3.
     """
-    normalized_path = storage._normalize_name(
-        prefixed_path).replace('\\', '/')
+    normalized_path = safe_join(storage.location, prefixed_path).replace(
+        '\\', '/')
     try:
         return storage.bucket.get_key(normalized_path).etag
     except AttributeError:

--- a/runtests.py
+++ b/runtests.py
@@ -50,7 +50,6 @@ def main():
                 'LOCATION': 'test-collectfast'
             }
         },
-        "ROOT_URLCONF": app_name + ".urls",
         "TEMPLATE_LOADERS": (
             "django.template.loaders.filesystem.Loader",
             "django.template.loaders.app_directories.Loader",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35,pypy}-django18,
-    {py27,py34,py35,pypy}-django110,
-    {py27,py34,py35,py36,pypy}-django111,
+    {py27,py33,py34,py35,pypy,pypy3}-django18,
+    {py27,py34,py35,pypy,pypy3}-django110,
+    {py27,py34,py35,py36,pypy,pypy3}-django111,
     flake8
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35,pypy,pypy3}-django18,
-    {py27,py34,py35,pypy,pypy3}-django110,
-    {py27,py34,py35,py36,pypy,pypy3}-django111,
+    {py27,py33,py34,py35,pypy}-django18,
+    {py27,py34,py35,pypy}-django110,
+    {py27,py34,py35,py36,pypy}-django111,
     flake8
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27,py33,py34,py35}-django18,
-    {py27,py34,py35}-django{19,110},
+    {py27,py34,py35}-django110,
     {py27,py34,py35,py36}-django111,
     flake8
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,15 @@
 [tox]
-envlist = py{27,33,34,35,36}-django{18,19,110}
+envlist =
+    {py27,py33,py34,py35}-django18,
+    {py27,py34,py35}-django{19,110},
+    {py27,py34,py35,py36}-django111,
+    flake8
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
     mock==1.3.0
     moto==0.4.31
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35}-django18,
-    {py27,py34,py35}-django110,
-    {py27,py34,py35,py36}-django111,
+    {py27,py33,py34,py35,pypy}-django18,
+    {py27,py34,py35,pypy}-django110,
+    {py27,py34,py35,py36,pypy}-django111,
     flake8
 [testenv]
 deps =


### PR DESCRIPTION
* replace access to private method _normalize_name() of django-storages' S3Boto3Storage with storages.utils.safe_join() it is using - this allows using collectfast with other storages, e.g. django-minio-storage as well ;)
* keep tox.ini in line with https://www.djangoproject.com/download/#supported-versions
* keep .travis.yml in line with tox.ini
* added .tox to .gitignore

Fixes #101 and enhances #99 