### PR TITLE
do not insist that AWS_PRELOAD_METADATA is true, so long as it is true on the storage class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,8 @@ to your ``INSTALLED_APPS``:
 Please note, that failure to do so will cause Django to use
 ``django.contrib.staticfiles``'s ``collectstatic``.
 
-**Note:** ``preload_metadata`` of the storage class will be overwritten
-even if ``AWS_PRELOAD_METADATA`` is not set to True see
-`#30 <https://github.com/jazzband/collectfast/issues/30>`_
+**Note:** ``preload_metadata`` of the storage class will be overwritten as
+`True`, see `#30 <https://github.com/jazzband/collectfast/issues/30>`_
 
 
 Usage

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -36,7 +36,7 @@ class Command(collectstatic.Command):
             self.storage.preload_metadata = True
             warnings.warn(
                 "Collectfast does not work properly without "
-                "`preload_metadata` set to `True` on the storage class. Try"
+                "`preload_metadata` set to `True` on the storage class. Try "
                 "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
                 "`storage.preload_metadata` and continuing.")
 

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -31,12 +31,13 @@ class Command(collectstatic.Command):
         self.num_copied_files = 0
         self.tasks = []
         self.etags = {}
-        self.storage.preload_metadata = True
         self.collectfast_enabled = settings.enabled
-        if not settings.preload_metadata_enabled:
+        if self.storage.preload_metadata is not True:
+            self.storage.preload_metadata = True
             warnings.warn(
                 "Collectfast does not work properly without "
-                "`AWS_PRELOAD_METADATA` set to `True`. Overriding "
+                "`preload_metadata` set to `True` on the storage class. Try"
+                "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
                 "`storage.preload_metadata` and continuing.")
 
     def set_options(self, **options):

--- a/collectfast/settings.py
+++ b/collectfast/settings.py
@@ -7,5 +7,3 @@ cache_key_prefix = getattr(
 cache = getattr(settings, "COLLECTFAST_CACHE", "default")
 threads = getattr(settings, "COLLECTFAST_THREADS", False)
 enabled = getattr(settings, "COLLECTFAST_ENABLED", True)
-preload_metadata_enabled = True is getattr(
-    settings, 'AWS_PRELOAD_METADATA', False)

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -2,6 +2,7 @@ import warnings
 
 from django.core.management import call_command
 from django.utils.six import StringIO
+from mock import patch
 
 from .utils import test, clean_static_dir, create_static_file, override_setting
 from .utils import with_bucket
@@ -40,9 +41,10 @@ def test_threads(case):
 
 
 @test
-@override_setting("preload_metadata_enabled", False)
 @with_bucket
-def test_warn_preload_metadata(case):
+@patch('django.contrib.staticfiles.management.commands.collectstatic.staticfiles_storage')  # noqa
+def test_warn_preload_metadata(case, mocked):
+    mocked.staticfiles_storage.return_value = False
     clean_static_dir()
     create_static_file()
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
i'm using several S3 storage classes for various things.  i don't want `AWS_PRELOAD_METADATA` set to True for any except for the static storage.  Seems to me that if we're overriding `preload_metadata` on the storage class, we could simply raise the warning if that settings isn't `True` on the storage class itself.

Note that this PR removes `collectfast.settings.preload_metadata_enabled`.