### PR TITLE
Properly handle non-S3 storage backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.egg-info
 /static/
 /static_root/
+.idea

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -40,19 +40,18 @@ class Command(collectstatic.Command):
         self.etags = {}
         self.collectfast_enabled = settings.enabled
         if settings.enabled:
-            if django_settings.STATICFILES_STORAGE in VALID_BACKENDS:
-                if self.storage.preload_metadata is not True:
-                    self.storage.preload_metadata = True
-                    warnings.warn(
-                        "Collectfast does not work properly without "
-                        "`preload_metadata` set to `True` on the storage "
-                        "class. Try setting `AWS_PRELOAD_METADATA` to `True`. "
-                        "Overriding `storage.preload_metadata` and continuing."
-                    )
-            else:
+            if django_settings.STATICFILES_STORAGE not in VALID_BACKENDS:
                 raise RuntimeError(
                     "Collectfast is intended to work with an S3 storage "
                     "backend only."
+                )
+            if self.storage.preload_metadata is not True:
+                self.storage.preload_metadata = True
+                warnings.warn(
+                    "Collectfast does not work properly without "
+                    "`preload_metadata` set to `True` on the storage "
+                    "class. Try setting `AWS_PRELOAD_METADATA` to `True`. "
+                    "Overriding `storage.preload_metadata` and continuing."
                 )
 
     def set_options(self, **options):

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -10,6 +10,12 @@ from collectfast.etag import should_copy_file
 from collectfast.boto import reset_connection
 from collectfast import settings
 
+# Backends with which Collectfast should work properly.
+VALID_BACKENDS = [
+    'storages.backends.s3boto3.S3Boto3Storage',
+    'storages.backends.s3boto.S3BotoStorage',
+]
+
 
 class Command(collectstatic.Command):
     def add_arguments(self, parser):
@@ -34,8 +40,7 @@ class Command(collectstatic.Command):
         self.etags = {}
         self.collectfast_enabled = settings.enabled
         if settings.enabled:
-            if django_settings.STATICFILES_STORAGE in ['storages.backends.s3boto3.S3Boto3Storage',
-                                                       'storages.backends.s3boto.S3BotoStorage']:
+            if django_settings.STATICFILES_STORAGE in VALID_BACKENDS:
                 if self.storage.preload_metadata is not True:
                     self.storage.preload_metadata = True
                     warnings.warn(

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -2,6 +2,7 @@ from __future__ import with_statement, unicode_literals
 from multiprocessing.dummy import Pool
 import warnings
 
+from django.conf import settings as django_settings
 from django.contrib.staticfiles.management.commands import collectstatic
 from django.utils.encoding import smart_str
 
@@ -32,13 +33,18 @@ class Command(collectstatic.Command):
         self.tasks = []
         self.etags = {}
         self.collectfast_enabled = settings.enabled
-        if settings.enabled and self.storage.preload_metadata is not True:
-            self.storage.preload_metadata = True
-            warnings.warn(
-                "Collectfast does not work properly without "
-                "`preload_metadata` set to `True` on the storage class. Try "
-                "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
-                "`storage.preload_metadata` and continuing.")
+        if settings.enabled:
+            if django_settings.STATICFILES_STORAGE in ['storages.backends.s3boto3.S3Boto3Storage',
+                                                       'storages.backends.s3boto.S3BotoStorage']:
+                if self.storage.preload_metadata is not True:
+                    self.storage.preload_metadata = True
+                    warnings.warn(
+                        "Collectfast does not work properly without "
+                        "`preload_metadata` set to `True` on the storage class. Try "
+                        "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
+                        "`storage.preload_metadata` and continuing.")
+            else:
+                raise RuntimeError('Collectfast is intended to work with an S3 storage backend only.')
 
     def set_options(self, **options):
         """

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -32,7 +32,7 @@ class Command(collectstatic.Command):
         self.tasks = []
         self.etags = {}
         self.collectfast_enabled = settings.enabled
-        if self.storage.preload_metadata is not True:
+        if settings.enabled and self.storage.preload_metadata is not True:
             self.storage.preload_metadata = True
             warnings.warn(
                 "Collectfast does not work properly without "

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -45,11 +45,15 @@ class Command(collectstatic.Command):
                     self.storage.preload_metadata = True
                     warnings.warn(
                         "Collectfast does not work properly without "
-                        "`preload_metadata` set to `True` on the storage class. Try "
-                        "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
-                        "`storage.preload_metadata` and continuing.")
+                        "`preload_metadata` set to `True` on the storage "
+                        "class. Try setting `AWS_PRELOAD_METADATA` to `True`. "
+                        "Overriding `storage.preload_metadata` and continuing."
+                    )
             else:
-                raise RuntimeError('Collectfast is intended to work with an S3 storage backend only.')
+                raise RuntimeError(
+                    "Collectfast is intended to work with an S3 storage "
+                    "backend only."
+                )
 
     def set_options(self, **options):
         """

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -2,6 +2,7 @@ import warnings
 
 from django.core.management import call_command
 from django.utils.six import StringIO
+from django.test import override_settings as override_django_setting
 from mock import patch
 
 from .utils import test, clean_static_dir, create_static_file, override_setting
@@ -57,6 +58,18 @@ def test_warn_preload_metadata(case, mocked):
 @override_setting("enabled", False)
 @with_bucket
 def test_collectfast_disabled(case):
+    clean_static_dir()
+    create_static_file()
+    call_collectstatic()
+
+
+@test
+@override_django_setting(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+@override_setting("enabled", False)
+@with_bucket
+def test_non_s3_storage(case):
     clean_static_dir()
     create_static_file()
     call_collectstatic()

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -76,6 +76,22 @@ def test_non_s3_storage(case):
 
 
 @test
+@override_django_setting(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+@with_bucket
+def test_enabled_with_non_s3_storage(case):
+    """
+    Running collectfast in enabled mode with a storage type other than S3 should
+    exit with an error.
+    """
+    clean_static_dir()
+    create_static_file()
+    with case.assertRaises(RuntimeError):
+        call_collectstatic()
+
+
+@test
 @with_bucket
 def test_disable_collectfast(case):
     clean_static_dir()


### PR DESCRIPTION
This PR addresses https://github.com/antonagestam/collectfast/issues/120. This bug causes Collectfast to crash when a non-S3 storage backend is configured.

I am not completely sure about the way I've implemented the storage type check, so please feel free to suggest alternative approaches. Regardless and in general - any comments and suggestions are very welcome.