### PR TITLE
do not suggest setting AWS_PRELOAD_METADATA=True

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,6 @@ to your ``INSTALLED_APPS``:
 .. code:: python
 
     STATICFILES_STORAGE = "storages.backends.s3boto.S3BotoStorage"
-    AWS_PRELOAD_METADATA = True
     INSTALLED_APPS = (
         # …
         'collectfast',

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -37,9 +37,8 @@ class Command(collectstatic.Command):
             self.storage.preload_metadata = True
             warnings.warn(
                 "Collectfast does not work properly without "
-                "`preload_metadata` set to `True` on the storage class. Try "
-                "setting `AWS_PRELOAD_METADATA` to `True`. Overriding "
-                "`storage.preload_metadata` and continuing.")
+                "`preload_metadata` set to `True` on the storage class. "
+                "Overriding `storage.preload_metadata` and continuing.")
 
     def set_options(self, **options):
         """


### PR DESCRIPTION
As some may know, the combination of `AWS_PRELOAD_METADATA=True` with S3Boto3Storage can have devastating consequences on large sites.

If suddenly set to `True` on a site that's using sorl-thumbnail (or others that create thumbnails on-demand), default_storage.exists() will check every object in the bucket every time.  Needless to say, if you have a high traffic site and a decent size bucket, your site is going down since it could take 30s for each .exists().

With all that said, collectfast is [overriding this during the command execution](https://github.com/antonagestam/collectfast/blob/master/collectfast/management/commands/collectstatic.py#L36-L42)

1. The warning does not need to suggest adding `AWS_PRELOAD_METADATA=True` as it would have no effect since it's being overridden anyway
2. README.rst should not suggest adding it to settings for the same reason

I foolishly experienced this on a production site without fully understanding the consequences of that setting and it cost me big, hoping this can save someone's trouble.





