### PR TITLE
Do not install typing library on Python3.5 or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "Django>=1.11",
         "django-storages>=1.6",
-        "typing",
+        'typing;python_version<"3.5"',
         "typing-extensions",
     ],
     classifiers=[

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-typing
+typing;python_version<"3.5"
 typing-extensions
 mock
 coveralls


### PR DESCRIPTION
The previous code will fail if the package is installed using **pip install -t**.

I use this library in the AWS Lambda with Python3.7 and to deploy a python project to the Lambda is required to use **pip install -t . -r requirements.txt** to download and store the project dependencies inside the current directory and after compress the directory and send to Lambda... When the `typing` is included as a dependency in Python3.7, the application raises an Exception:

```
AttributeError: type object 'Callable' has no attribute '_abc_registry'
Traceback (most recent call last):
  File "/var/lang/lib/python3.7/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/lambda.py", line 4, in <module>
    import sentry_sdk
  File "/var/task/sentry_sdk/__init__.py", line 1, in <module>
    from sentry_sdk.hub import Hub, init
  File "/var/task/sentry_sdk/hub.py", line 8, in <module>
    from sentry_sdk._compat import with_metaclass
  File "/var/task/sentry_sdk/_compat.py", line 3, in <module>
    from sentry_sdk._types import MYPY
  File "/var/task/sentry_sdk/_types.py", line 2, in <module>
    from typing import TYPE_CHECKING as MYPY
  File "/var/task/typing.py", line 1357, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/var/task/typing.py", line 1005, in __new__
    self._abc_registry = extra._abc_registry
```


## Proof
Installing on Python3.4 with a clean virtualenv:

![image](https://user-images.githubusercontent.com/807599/70184323-614d1a00-16c6-11ea-9d9d-9caf698e48a0.png)


![image](https://user-images.githubusercontent.com/807599/70184074-d79d4c80-16c5-11ea-9701-210f6e72992a.png)


Installing on Python3.7 with a clean virtualenv:

![image](https://user-images.githubusercontent.com/807599/70184146-087d8180-16c6-11ea-9b53-f3e0eae14d88.png)

![image](https://user-images.githubusercontent.com/807599/70184199-22b75f80-16c6-11ea-8145-4cb760d0e1e8.png)

