### PR TITLE
Fix: Limit django-storages to <1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=1.11",
-        "django-storages>=1.6",
+        "django-storages>=1.6,<1.9",
         'typing;python_version<"3.5"',
         "typing-extensions",
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ typing;python_version<"3.5"
 typing-extensions
 mock
 coveralls
-django-storages
+django-storages<1.9
 boto3
 boto
 google-cloud-storage


### PR DESCRIPTION
In django-storages 1.9 the long deprecated boto storage has finally been removed, see https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#19-2020-02-02