### PR TITLE
Fix/aws multipart hashes (Fixes #201)

### DIFF
--- a/collectfast/tests/command/test_command.py
+++ b/collectfast/tests/command/test_command.py
@@ -53,6 +53,16 @@ def test_basics(case: TestCase) -> None:
     case.assertIn("0 static files copied.", call_collectstatic())
 
 
+@make_test_aws_backends
+@live_test
+def test_aws_large_file(case: TestCase) -> None:
+    clean_static_dir()
+    create_static_file(size=10485760)
+    case.assertIn("1 static file copied.", call_collectstatic())
+    # file state should now be cached
+    case.assertIn("0 static files copied.", call_collectstatic())
+
+
 @make_test_all_backends
 @live_test
 @override_setting("threads", 5)

--- a/collectfast/tests/utils.py
+++ b/collectfast/tests/utils.py
@@ -64,10 +64,10 @@ def test_many(**mutations: Callable[[F], F]) -> Callable[[F], Type[unittest.Test
     return test
 
 
-def create_static_file() -> pathlib.Path:
+def create_static_file(size: int = 500) -> pathlib.Path:
     """Write random characters to a file in the static directory."""
     path = static_dir / f"{uuid.uuid4().hex}.txt"
-    path.write_text("".join(chr(random.randint(0, 64)) for _ in range(500)))
+    path.write_text("".join(chr(random.randint(0, 64)) for _ in range(size)))
     return path
 
 


### PR DESCRIPTION
Here's a first draft of changes to handle hashing multipart uploads to match the ETag on S3. I'm really not sure about the structure of the change, let me know if you'd like it implemented some other way.

I wasn't able to get the live test running locally but I think it should pass. I tested with a project of mine and it seems to work.

Gzip support is not implemented at this point.