### PR TITLE
Implement OpenStack Swift support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Implement OpenStack Swift support.
+- Add `pre_collect_hook` to `collectfast.strategies.base.Strategy`.
+- Replace `test_many` test generator with pytest parametrize.
+- Add pytest marks for easy test selection.
+- Add pytest skip checks for storage settings and dependencies.
+- Add tests for `S3ManifestStaticStorage`.
+- Replace `override_storage_attr` with `mock.patch.object` to support
+  overriding instance attributes.
+
 ## 2.2.0
 
 - Add `post_copy_hook` and `on_skip_hook` to

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 SHELL := /usr/bin/env bash
 
 test:
+ifdef mark
+	. storage-credentials && pytest -m "$(mark)"
+else
 	. storage-credentials && pytest
+endif
 
 test-skip-live:
 	SKIP_LIVE_TESTS=true pytest

--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -67,6 +67,9 @@ class Command(collectstatic.Command):
         Override collect to copy files concurrently. The tasks are populated by
         Command.copy_file() which is called by super().collect().
         """
+        if self.collectfast_enabled:
+            self.strategy.pre_collect_hook()
+
         if not self.collectfast_enabled or not settings.threads:
             return super().collect()
 
@@ -91,8 +94,9 @@ class Command(collectstatic.Command):
         ret = super().handle(**options)
         if not self.collectfast_enabled:
             return ret
-        plural = "" if self.num_copied_files == 1 else "s"
-        return f"{self.num_copied_files} static file{plural} copied."
+        if self.verbosity >= 1:
+            plural = "" if self.num_copied_files == 1 else "s"
+            return f"{self.num_copied_files} static file{plural} copied."
 
     def maybe_copy_file(self, args: Task) -> None:
         """Determine if file should be copied or not and handle exceptions."""

--- a/collectfast/settings.py
+++ b/collectfast/settings.py
@@ -28,6 +28,8 @@ cache: Final = _get_setting(str, "COLLECTFAST_CACHE", "default")
 threads: Final = _get_setting(int, "COLLECTFAST_THREADS", 0)
 enabled: Final = _get_setting(bool, "COLLECTFAST_ENABLED", True)
 aws_is_gzipped: Final = _get_setting(bool, "AWS_IS_GZIPPED", False)
+# Provide an override for storages that use a different gzip compression level.
+gzip_compresslevel: Final = _get_setting(int, "COLLECTFAST_GZIP_COMPRESSLEVEL", 9)
 gzip_content_types: Final[Container] = _get_setting(
     tuple,
     "GZIP_CONTENT_TYPES",

--- a/collectfast/strategies/base.py
+++ b/collectfast/strategies/base.py
@@ -50,6 +50,10 @@ class Strategy(abc.ABC, Generic[_RemoteStorage]):
         """
         ...
 
+    def pre_collect_hook(self) -> None:
+        """Hook called before running collect."""
+        ...
+
     def pre_should_copy_hook(self) -> None:
         """Hook called before calling should_copy_file."""
         ...
@@ -81,7 +85,12 @@ class HashStrategy(Strategy[_RemoteStorage], abc.ABC):
         self, uncompressed_file_hash: str, path: str, contents: str
     ) -> str:
         buffer = BytesIO()
-        zf = gzip.GzipFile(mode="wb", fileobj=buffer, mtime=0.0)
+        zf = gzip.GzipFile(
+            mode="wb",
+            fileobj=buffer,
+            mtime=0.0,
+            compresslevel=settings.gzip_compresslevel,
+        )
         zf.write(force_bytes(contents))
         zf.close()
         return hashlib.md5(buffer.getvalue()).hexdigest()

--- a/collectfast/strategies/swift.py
+++ b/collectfast/strategies/swift.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Optional
+
+from swift.storage import StaticSwiftStorage
+
+from .base import CachingHashStrategy
+from collectfast import settings
+
+logger = logging.getLogger(__name__)
+
+
+class OpenStackSwiftStrategy(CachingHashStrategy[StaticSwiftStorage]):
+    def __init__(self, remote_storage: StaticSwiftStorage) -> None:
+        super().__init__(remote_storage)
+        self.remote_hashes = {}
+        # gzip support is available on github but not in the pypi release.
+        if getattr(remote_storage, "gzip_content_types", []):
+            self.use_gzip = True
+            settings.gzip_compresslevel = remote_storage.gzip_compression_level
+            settings.gzip_content_types = remote_storage.gzip_content_types
+            if (
+                remote_storage.gzip_unknown_content_type
+                and "application/octet-stream" not in settings.gzip_content_types
+            ):
+                settings.gzip_content_types.append("application/octet-stream")
+
+    def pre_collect_hook(self) -> None:
+        # Collect the object listing with hashes once and share it with all threads.
+        self.remote_hashes = dict(
+            (obj["name"], obj["hash"])
+            for obj in self.remote_storage.swift_conn.get_container(
+                self.remote_storage.container_name, full_listing=True
+            )[1]
+        )
+
+    def get_remote_file_hash(self, prefixed_path: str) -> Optional[str]:
+        return self.remote_hashes.get(prefixed_path)
+
+    def pre_should_copy_hook(self) -> None:
+        if settings.threads:
+            logger.info("Resetting connection")
+            self.remote_storage._swift_conn = None

--- a/collectfast/tests/command/test_command.py
+++ b/collectfast/tests/command/test_command.py
@@ -1,8 +1,13 @@
 from unittest import mock
 from unittest import TestCase
 
+import pytest
+from _pytest.fixtures import SubRequest
+from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings as override_django_settings
+from pytest_django.fixtures import SettingsWrapper
 
 from .utils import call_collectstatic
 from collectfast.management.commands.collectstatic import Command
@@ -11,41 +16,108 @@ from collectfast.tests.utils import create_static_file
 from collectfast.tests.utils import live_test
 from collectfast.tests.utils import make_test
 from collectfast.tests.utils import override_setting
-from collectfast.tests.utils import override_storage_attr
-from collectfast.tests.utils import test_many
 
 
-aws_backend_confs = {
-    "boto3": override_django_settings(
-        STATICFILES_STORAGE="storages.backends.s3boto3.S3Boto3Storage",
-        COLLECTFAST_STRATEGY="collectfast.strategies.boto3.Boto3Strategy",
+gzip_backend_confs = [
+    pytest.param(
+        "storages.backends.s3boto3.S3StaticStorage",
+        "collectfast.strategies.boto3.Boto3Strategy",
+        marks=[
+            pytest.mark.boto3,
+            pytest.mark.skipif(
+                not settings.AWS_ACCESS_KEY_ID, reason="AWS credentials are not set"
+            ),
+        ],
+        id="boto3",
     ),
-}
-all_backend_confs = {
-    **aws_backend_confs,
-    "gcloud": override_django_settings(
-        STATICFILES_STORAGE="storages.backends.gcloud.GoogleCloudStorage",
-        COLLECTFAST_STRATEGY="collectfast.strategies.gcloud.GoogleCloudStrategy",
+    pytest.param(
+        "storages.backends.s3boto3.S3ManifestStaticStorage",
+        "collectfast.strategies.boto3.Boto3Strategy",
+        marks=[
+            pytest.mark.boto3,
+            pytest.mark.skipif(
+                not settings.AWS_ACCESS_KEY_ID, reason="AWS credentials are not set"
+            ),
+        ],
+        id="boto3-manifest",
     ),
-    "filesystem": override_django_settings(
-        STATICFILES_STORAGE="django.core.files.storage.FileSystemStorage",
-        COLLECTFAST_STRATEGY="collectfast.strategies.filesystem.FileSystemStrategy",
+    pytest.param(
+        "swift.storage.StaticSwiftStorage",
+        "collectfast.strategies.swift.OpenStackSwiftStrategy",
+        marks=[
+            pytest.mark.swift,
+            pytest.mark.skipif(
+                not settings.SWIFT_AUTH_URL,
+                reason="Openstack Swift credentials are not set",
+            ),
+        ],
+        id="swift",
     ),
-    "cachingfilesystem": override_django_settings(
-        STATICFILES_STORAGE="django.core.files.storage.FileSystemStorage",
-        COLLECTFAST_STRATEGY=(
-            "collectfast.strategies.filesystem.CachingFileSystemStrategy"
-        ),
+]
+all_backend_confs = gzip_backend_confs + [
+    pytest.param(
+        "django.core.files.storage.FileSystemStorage",
+        "collectfast.strategies.filesystem.CachingFileSystemStrategy",
+        marks=pytest.mark.filesystem,
+        id="filesystem-caching",
     ),
-}
+    pytest.param(
+        "django.core.files.storage.FileSystemStorage",
+        "collectfast.strategies.filesystem.FileSystemStrategy",
+        marks=pytest.mark.filesystem,
+        id="filesystem",
+    ),
+    pytest.param(
+        "storages.backends.gcloud.GoogleCloudStorage",
+        "collectfast.strategies.gcloud.GoogleCloudStrategy",
+        marks=[
+            pytest.mark.gcloud,
+            pytest.mark.skipif(
+                not settings.GS_CREDENTIALS,
+                reason="Google Cloud credentials are not set",
+            ),
+        ],
+        id="gcloud",
+    ),
+]
 
-make_test_aws_backends = test_many(**aws_backend_confs)
-make_test_all_backends = test_many(**all_backend_confs)
+
+@pytest.fixture
+def gzip(storage: str) -> None:
+    if "s3boto3" in storage:
+        with mock.patch.object(staticfiles_storage, "gzip", True):
+            yield
+    elif "swift" in storage:
+        if not hasattr(staticfiles_storage, "gzip_content_types"):
+            pytest.skip("django-storage-swift release without gzip support")
+        with mock.patch.object(
+            staticfiles_storage, "gzip_content_types", ("text/plain",)
+        ):
+            yield
 
 
-@make_test_all_backends
+@pytest.fixture(scope="function")
+def storage(settings: SettingsWrapper, request: SubRequest):
+    if "swift" in request.param:
+        pytest.importorskip("swift")  # Cannot be used with parametrize params.
+    settings.STATICFILES_STORAGE = request.param
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def strategy(settings: SettingsWrapper, request: SubRequest):
+    settings.COLLECTFAST_STRATEGY = request.param
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def case() -> TestCase:
+    return TestCase()
+
+
+@pytest.mark.parametrize("storage,strategy", all_backend_confs, indirect=True)
 @live_test
-def test_basics(case: TestCase) -> None:
+def test_basics(case: TestCase, strategy: str, storage: str) -> None:
     clean_static_dir()
     create_static_file()
     case.assertIn("1 static file copied.", call_collectstatic())
@@ -53,10 +125,10 @@ def test_basics(case: TestCase) -> None:
     case.assertIn("0 static files copied.", call_collectstatic())
 
 
-@make_test_all_backends
+@pytest.mark.parametrize("storage,strategy", all_backend_confs, indirect=True)
 @live_test
 @override_setting("threads", 5)
-def test_threads(case: TestCase) -> None:
+def test_threads(case: TestCase, strategy: str, storage: str) -> None:
     clean_static_dir()
     create_static_file()
     case.assertIn("1 static file copied.", call_collectstatic())
@@ -77,11 +149,10 @@ def test_dry_run(case: TestCase) -> None:
     case.assertTrue("Pretending to delete", result)
 
 
-@make_test_aws_backends
+@pytest.mark.parametrize("storage,strategy", gzip_backend_confs, indirect=True)
 @live_test
-@override_storage_attr("gzip", True)
 @override_setting("aws_is_gzipped", True)
-def test_aws_is_gzipped(case: TestCase) -> None:
+def test_gzip(case: TestCase, gzip: None, strategy: str, storage: str) -> None:
     clean_static_dir()
     create_static_file()
     case.assertIn("1 static file copied.", call_collectstatic())
@@ -96,10 +167,12 @@ def test_raises_for_no_configured_strategy(case: TestCase) -> None:
         Command._load_strategy()
 
 
-@make_test_all_backends
+@pytest.mark.parametrize("storage,strategy", all_backend_confs, indirect=True)
 @live_test
 @mock.patch("collectfast.strategies.base.Strategy.post_copy_hook", autospec=True)
-def test_calls_post_copy_hook(_case: TestCase, post_copy_hook: mock.MagicMock) -> None:
+def test_calls_post_copy_hook(
+    post_copy_hook: mock.MagicMock, case: TestCase, strategy: str, storage: str
+) -> None:
     clean_static_dir()
     path = create_static_file()
     cmd = Command()
@@ -107,10 +180,12 @@ def test_calls_post_copy_hook(_case: TestCase, post_copy_hook: mock.MagicMock) -
     post_copy_hook.assert_called_once_with(mock.ANY, path.name, path.name, mock.ANY)
 
 
-@make_test_all_backends
+@pytest.mark.parametrize("storage,strategy", all_backend_confs, indirect=True)
 @live_test
 @mock.patch("collectfast.strategies.base.Strategy.on_skip_hook", autospec=True)
-def test_calls_on_skip_hook(_case: TestCase, on_skip_hook: mock.MagicMock) -> None:
+def test_calls_on_skip_hook(
+    on_skip_hook: mock.MagicMock, case: TestCase, strategy: str, storage: str
+) -> None:
     clean_static_dir()
     path = create_static_file()
     cmd = Command()

--- a/collectfast/tests/command/test_disable.py
+++ b/collectfast/tests/command/test_disable.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from unittest import TestCase
 
+import pytest
+from django.conf import settings
 from django.test import override_settings as override_django_settings
 
 from .utils import call_collectstatic
@@ -23,6 +25,10 @@ def test_disable_collectfast_with_default_storage(case: TestCase) -> None:
 
 @make_test
 @live_test
+@pytest.mark.boto3  # default test storage is boto3
+@pytest.mark.skipif(
+    not settings.AWS_ACCESS_KEY_ID, reason="AWS credentials are not set"
+)
 def test_disable_collectfast(case: TestCase) -> None:
     clean_static_dir()
     create_static_file()

--- a/collectfast/tests/settings.py
+++ b/collectfast/tests/settings.py
@@ -4,6 +4,8 @@ import tempfile
 
 from google.oauth2 import service_account
 
+env = os.environ.get
+
 base_path = pathlib.Path.cwd()
 
 # Set USE_TZ to True to work around bug in django-storages
@@ -27,27 +29,29 @@ STATIC_URL = "/staticfiles/"
 STATIC_ROOT = str(base_path / "static_root")
 MEDIA_ROOT = str(base_path / "fs_remote")
 STATICFILES_DIRS = [str(base_path / "static")]
-STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STATICFILES_STORAGE = "storages.backends.s3boto3.S3StaticStorage"
 COLLECTFAST_STRATEGY = "collectfast.strategies.boto3.Boto3Strategy"
 COLLECTFAST_DEBUG = True
+COLLECTFAST_GZIP_COMPRESSLEVEL = 9
 
 GZIP_CONTENT_TYPES = ("text/plain",)
 
 # AWS
 AWS_PRELOAD_METADATA = True
-AWS_STORAGE_BUCKET_NAME = "collectfast"
+AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", "collectfast")
 AWS_IS_GZIPPED = False
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "").strip()
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip()
-AWS_S3_REGION_NAME = "eu-central-1"
-AWS_S3_SIGNATURE_VERSION = "s3v4"
-AWS_QUERYSTRING_AUTH = False
+AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY")
+AWS_S3_ENDPOINT_URL = env("AWS_S3_ENDPOINT_URL")
+AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME")
+AWS_S3_SIGNATURE_VERSION = env("AWS_S3_SIGNATURE_VERSION", "s3v4")
+AWS_QUERYSTRING_AUTH = False  # This is also enforced by S3StaticStorage
 AWS_DEFAULT_ACL = None
 S3_USE_SIGV4 = True
-AWS_S3_HOST = "s3.eu-central-1.amazonaws.com"
+
 
 # Google Cloud
-gcloud_credentials_json = os.environ.get("GCLOUD_CREDENTIALS", "").strip()
+gcloud_credentials_json = env("GCLOUD_CREDENTIALS")
 if not gcloud_credentials_json:
     GS_CREDENTIALS = None
 else:
@@ -57,4 +61,15 @@ else:
         GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
             file.name
         )
-GS_BUCKET_NAME = "roasted-dufus"
+GS_BUCKET_NAME = env("GS_BUCKET_NAME", "roasted-dufus")
+
+# OpenStack Swift
+SWIFT_AUTH_URL = env("SWIFT_AUTH_URL")
+SWIFT_PROJECT_ID = env("SWIFT_PROJECT_ID")
+SWIFT_PROJECT_NAME = env("SWIFT_PROJECT_NAME")
+SWIFT_USER_DOMAIN_NAME = env("SWIFT_USER_DOMAIN_NAME")
+SWIFT_PROJECT_DOMAIN_ID = env("SWIFT_PROJECT_DOMAIN_ID")
+SWIFT_USERNAME = env("SWIFT_USERNAME")
+SWIFT_PASSWORD = env("SWIFT_PASSWORD")
+SWIFT_REGION_NAME = env("SWIFT_REGION_NAME")
+SWIFT_STATIC_CONTAINER_NAME = env("SWIFT_STATIC_CONTAINER_NAME")

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 flake8-bugbear
-black
+# sorti has been archived and requires an old black release.
+black==19.10b0
 sorti
 mypy>=0.761
 django-stubs>=1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ install_requires =
     typing-extensions
 python_requires = >=3.6
 
+[options.extras_require]
+swift = django-storage-swift>=1.2.19
+
 [options.package_data]
 collectfast = py.typed
 
@@ -37,6 +40,12 @@ universal = true
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = collectfast.tests.settings
+addopts = --strict-markers
+markers =
+    boto3: marks tests for the boto3 storage.
+    filesystem: marks tests for the filesystem storage.
+    gcloud: marks tests for the gcloud storage.
+    swift: marks tests for the swift storage.
 
 [flake8]
 exclude = appveyor, .idea, .git, .venv, .tox, __pycache__, *.egg-info, build
@@ -74,7 +83,7 @@ plugins =
 [mypy.plugins.django-stubs]
 django_settings_module = collectfast.tests.settings
 
-[mypy-storages.*,google.*,botocore.*,setuptools.*,pytest.*]
+[mypy-storages.*,google.*,botocore.*,swift.*,setuptools.*,pytest.*]
 ignore_missing_imports = True
 
 [coverage:run]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,6 @@ coveralls
 django-storages
 boto3
 google-cloud-storage
+django-storage-swift
 pytest
 pytest-django


### PR DESCRIPTION
- Implement OpenStack Swift support using django-storage-swift.
- Add `pre_collect_hook` to `collectfast.strategies.base.Strategy`.
- Replace `test_many` test generator with pytest parametrize.
- Add pytest marks for easy test selection.
- Add pytest skip checks for storage settings and dependencies.
- Add tests for `S3ManifestStaticStorage`.
- Replace `override_storage_attr` with `mock.patch.object` to support
  overriding instance attributes.

I realize the scope of this pull request suffers from creep but the primary intention was to get a fork working for us.
The pytest changes add some great quality of life improvements for development and testing of specific storage backends.

To support the `OpenStackSwiftStrategy` we only really need a `pre_collect_hook` and `gzip_compresslevel` setting provided by collectfast and I'll happily make a separate pull request for that if you do not want to accept another 3rd party storage backend/strategy.
OpenStack Swift was developed and open sourced by Rackspace https://docs.openstack.org/swift/latest/