### PR TITLE
Don't suppress errors when using threads

### DIFF
--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -78,7 +78,12 @@ class Command(collectstatic.Command):
         return_value = super().collect()
 
         with ThreadPoolExecutor(settings.threads) as pool:
-            pool.map(self.maybe_copy_file, self.tasks)
+            result_futures = list(map(lambda x: pool.submit(self.maybe_copy_file, x), self.tasks))
+            for future in as_completed(result_futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    raise(e)
 
         self.maybe_post_process(super_post_process)
         return_value["post_processed"] = self.post_processed_files


### PR DESCRIPTION
When I was using collectfast in a CI system, some of the assets were not copied.
Sometimes it copied all, sometimes just a subset without any errors.

This is what I experienced:

    ~ $ python manage.py collectstatic --noinput --disable-collectfast
    1249 static files copied, 59 unmodified.
    ~ $
    ~ $ echo 'Deleting the files from AWS now'
    Deleting the files from AWS now
    ~ $
    ~ $ python manage.py collectstatic --noinput
    790 static files copied.
    ~ $ python manage.py collectstatic --noinput
    518 static files copied.
    ~ $ python manage.py collectstatic --noinput
    0 static files copied.
    ~ $ python manage.py collectstatic --noinput
    0 static files copied.
    ~ $
    ~ $ echo 'Deleting the files from AWS now'
    Deleting the files from AWS now
    ~ $
    ~ $ python manage.py collectstatic --noinput
    697 static files copied.
    ~ $ python manage.py collectstatic --noinput
    611 static files copied.
    ~ $ python manage.py collectstatic --noinput
    0 static files copied.
    ~ $ python manage.py collectstatic --noinput
    0 static files copied.
    ~ $
    ~ $

It turned out, that the redis cache I used has some connection limits, so in the background I was having `redis.exceptions.ConnectionError: max number of clients reached` errors without being notified.

The `collectstatic` build step succeeded all times while having these errors and not copying some files.


The proposed fix simply waits for all the results and re-raises any errors, so the `collectstatic` command will fail loudly when an error happens in at least one thread.

(I wanted to write a test for this, but wasn't able to get the test suite running so I gave it up.)