### PR TITLE
Changed log level in pre_should_copy_hook method.

### DIFF
--- a/collectfast/strategies/boto3.py
+++ b/collectfast/strategies/boto3.py
@@ -42,5 +42,5 @@ class Boto3Strategy(CachingHashStrategy[S3Boto3Storage]):
 
     def pre_should_copy_hook(self) -> None:
         if settings.threads:
-            logger.info("Resetting connection")
+            logger.debug("Resetting connection")
             self.remote_storage._connection = None


### PR DESCRIPTION
Log level of message in `pre_should_copy_hook` method of `Boto3Strategy` could be changed to debug since it's not so relevant in basic usage.